### PR TITLE
Add economy command system

### DIFF
--- a/src/commands/economy/DailyCommand.ts
+++ b/src/commands/economy/DailyCommand.ts
@@ -1,0 +1,78 @@
+import { Command } from "../Command.js";
+import { CommandCategory } from "@/types/index.js";
+import type { MessageContext } from "@/types/index.js";
+import { serviceManager } from "@/services/Servicemanager.js";
+import { formatNumber, formatTime } from "@/utils/helpers.js";
+
+export class DailyCommand extends Command {
+  name = "daily";
+  description = "Claim your daily reward";
+  category = CommandCategory.ECONOMY;
+  aliases = ["daily"];
+  usage = "!daily";
+  cooldown = 1000;
+
+  async execute(ctx: MessageContext): Promise<void> {
+    const user = await serviceManager.userService.getUser(ctx.sender.jid);
+
+    if (!this.canClaim(user.lastDaily)) {
+      const remaining = this.getTimeRemaining(user.lastDaily);
+      await ctx.reply(
+        `You have already claimed your daily reward.\n\n` +
+          `Available again in: ${formatTime(remaining)}`,
+      );
+      return;
+    }
+
+    const streak = this.calculateStreak(user.lastDaily);
+    const baseReward = 1000;
+    const streakBonus = Math.min(streak * 100, 1000);
+    const totalReward = baseReward + streakBonus;
+
+    await serviceManager.userService.addMoney(ctx.sender.jid, totalReward);
+    await serviceManager.userService.updateUser(ctx.sender.jid, {
+      lastDaily: Date.now(),
+    });
+
+    await serviceManager.levelService.addXP(ctx.sender.jid, 50);
+
+    const updatedUser = await serviceManager.userService.getUser(
+      ctx.sender.jid,
+    );
+
+    await ctx.reply(
+      `*DAILY REWARD*\n\n` +
+        `+$${formatNumber(totalReward)}\n` +
+        `Streak: ${streak} days\n` +
+        `+50 XP\n\n` +
+        `Balance: $${formatNumber(updatedUser.money)}`,
+    );
+  }
+
+  private canClaim(lastDaily?: number): boolean {
+    if (!lastDaily) return true;
+    const oneDayMs = 24 * 60 * 60 * 1000;
+    return Date.now() - lastDaily >= oneDayMs;
+  }
+
+  private getTimeRemaining(lastDaily?: number): number {
+    if (!lastDaily) return 0;
+    const oneDayMs = 24 * 60 * 60 * 1000;
+    const remaining = lastDaily + oneDayMs - Date.now();
+    return Math.max(0, remaining);
+  }
+
+  private calculateStreak(lastDaily?: number): number {
+    if (!lastDaily) return 1;
+
+    const daysSince = Math.floor(
+      (Date.now() - lastDaily) / (24 * 60 * 60 * 1000),
+    );
+
+    if (daysSince > 2) return 1;
+
+    if (daysSince === 1) return 2;
+
+    return 1;
+  }
+}

--- a/src/commands/economy/PayCommand.ts
+++ b/src/commands/economy/PayCommand.ts
@@ -1,0 +1,63 @@
+import { Command } from "../Command.js";
+import { CommandCategory } from "@/types/index.js";
+import type { MessageContext } from "@/types/index.js";
+import { serviceManager } from "@/services/Servicemanager.js";
+import { formatNumber } from "@/utils/helpers.js";
+
+export class PayCommand extends Command {
+  name = "pay";
+  description = "Transfer money to another user";
+  category = CommandCategory.ECONOMY;
+  aliases = ["pay", "transfer"];
+  usage = "!pay @user <quantity>";
+  examples = ["!pay @5215551234567 500"];
+  cooldown = 5000;
+
+  async execute(ctx: MessageContext): Promise<void> {
+    const mentionedJid =
+      ctx.message.message?.extendedTextMessage?.contextInfo?.mentionedJid?.[0];
+
+    if (!mentionedJid) {
+      await ctx.reply(
+        "You must mention a user.\n\nUsage: !pay @user <quantity>",
+      );
+      return;
+    }
+
+    if (mentionedJid === ctx.sender.jid) {
+      await ctx.reply("You cannot transfer money to yourself.");
+      return;
+    }
+
+    const amountStr = ctx.args[1];
+    const amount = parseInt(amountStr);
+
+    if (!amountStr || isNaN(amount) || amount <= 0) {
+      await ctx.reply("Invalid amount\n\Usage: !pay @user <quantity>");
+      return;
+    }
+
+    const sender = await serviceManager.userService.getUser(ctx.sender.jid);
+
+    if (sender.money < amount) {
+      await ctx.reply(
+        `You don't have enough money.\n\n` +
+          `Your balance: $${formatNumber(sender.money)}\n` +
+          `You need: $${formatNumber(amount)}`,
+      );
+      return;
+    }
+
+    await serviceManager.userService.removeMoney(ctx.sender.jid, amount);
+    await serviceManager.userService.addMoney(mentionedJid, amount);
+
+    const receiver = await serviceManager.userService.getUser(mentionedJid);
+
+    await ctx.reply(
+      `*SUCCESSFUL TRANSFER*\n\n` +
+        `You sent: $${formatNumber(amount)}\n` +
+        `For: ${receiver.name}\n\n` +
+        `Your new balance: $${formatNumber(sender.money - amount)}`,
+    );
+  }
+}

--- a/src/commands/economy/WorkCommand.ts
+++ b/src/commands/economy/WorkCommand.ts
@@ -1,0 +1,43 @@
+import { Command } from "../Command.js";
+import { CommandCategory } from "@/types/index.js";
+import type { MessageContext } from "@/types/index.js";
+import { serviceManager } from "@/services/Servicemanager.js";
+import { formatNumber } from "@/utils/helpers.js";
+
+export class WorkCommand extends Command {
+  name = "work";
+  description = "Work to earn money";
+  category = CommandCategory.ECONOMY;
+  aliases = ["work"];
+  usage = "!work";
+  cooldown = 60 * 60 * 1000;
+
+  private readonly JOBS = [
+    { name: "Programmer", min: 500, max: 1500, emoji: "💻" },
+    { name: "Chef", min: 300, max: 1000, emoji: "👨‍🍳" },
+    { name: "Driver", min: 200, max: 800, emoji: "🚗" },
+    { name: "Teacher", min: 400, max: 1200, emoji: "👨‍🏫" },
+    { name: "Musician", min: 250, max: 900, emoji: "🎸" },
+  ];
+
+  async execute(ctx: MessageContext): Promise<void> {
+    const job = this.JOBS[Math.floor(Math.random() * this.JOBS.length)];
+    const earned =
+      Math.floor(Math.random() * (job.max - job.min + 1)) + job.min;
+
+    await serviceManager.userService.addMoney(ctx.sender.jid, earned);
+
+    const xpGained = Math.floor(earned / 10);
+    await serviceManager.levelService.addXP(ctx.sender.jid, xpGained);
+
+    const user = await serviceManager.userService.getUser(ctx.sender.jid);
+
+    await ctx.reply(
+      `${job.emoji} *WORK COMPLETED*\n\n` +
+        `You worked as: ${job.name}\n` +
+        `💰 Earned: $${formatNumber(earned)}\n` +
+        `⚡ XP: +${xpGained}\n\n` +
+        `💵 Balance: $${formatNumber(user.money)}`,
+    );
+  }
+}


### PR DESCRIPTION
Description:
This PR adds the economy command module to the bot. All commands are located under src/commands/economy/ and use UserService for reading and writing user balances.
Commands included: (list based on what is in the folder)

1. Balance: shows current user balance
2. Daily: claims daily reward with cooldown
3. Transfer: sends currency to another user

All commands follow the existing command interface pattern and are loaded automatically by PluginLoader.
Testing:

1. Run balance command as a regular user
2. Run daily command twice and verify cooldown triggers on second call
3. Run transfer command and verify sender and receiver balances update correctly

ticket: 
Closes #44 