### PR TITLE
Fix/subbot persistence and api key init

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -275,6 +275,33 @@ check_persistence() {
   echo "$file_count"
 }
 
+migrate_subbot_sessions() {
+  info "${GHOST}verificando migración de sesiones de subbots...${NC}"
+  local OLD_PATH="/app/data/subbot-sessions"
+  local NEW_PATH="/app/subbot-sessions"
+
+  local old_count=$(docker run --rm -v vaniabot_database:/check alpine sh -c "ls -1 /check${OLD_PATH} 2>/dev/null | wc -l" 2>/dev/null || echo "0")
+  local new_count=$(docker run --rm -v vaniabot_subbot_sessions:/check alpine sh -c "ls -1 /check${NEW_PATH} 2>/dev/null | wc -l" 2>/dev/null || echo "0")
+
+  if [ "$old_count" -gt 2 ] && [ "$new_count" -le 2 ]; then
+    info "${NEON_YELLOW}Migrando sesiones de ${OLD_PATH} → ${NEW_PATH}${NC}"
+    docker run --rm \
+      -v vaniabot_database:/old \
+      -v vaniabot_subbot_sessions:/new \
+      alpine sh -c "
+        mkdir -p /new/subbot-sessions
+        cp -a /old${OLD_PATH}/. /new${NEW_PATH}/ 2>/dev/null || true
+        chown -R 1001:1001 /new${NEW_PATH} 2>/dev/null || true
+      " 2>/dev/null \
+      && ok "Sesiones migradas: ${NEON_GREEN}${BOLD}$((old_count-2)) sesiones${NC}" \
+      || warn "Migración falló — sesiones originales intactas"
+  elif [ "$new_count" -gt 2 ]; then
+    ok "Sesiones ya en ubicación correcta: ${NEON_GREEN}${BOLD}$((new_count-2)) sesiones${NC}"
+  else
+    info "${GHOST}Sin sesiones previas para migrar${NC}"
+  fi
+}
+
 fix_permissions() {
   local vol_name="$1"
   local mount_path="$2"
@@ -348,7 +375,14 @@ if $UPDATE_MODE; then
   SESSION_COUNT=$(check_persistence "vaniabot_session" "")
   DB_COUNT=$(check_persistence "vaniabot_database" "")
   STORAGE_COUNT=$(check_persistence "vaniabot_storage" "")
-  SUBBOT_COUNT=$(check_persistence "vaniabot_subbot_sessions" "")
+
+  OLD_SUBBOT_COUNT=$(check_persistence "vaniabot_database" "/data/subbot-sessions")
+  NEW_SUBBOT_COUNT=$(check_persistence "vaniabot_subbot_sessions" "")
+  if [ "$NEW_SUBBOT_COUNT" -gt 2 ]; then
+    SUBBOT_COUNT=$NEW_SUBBOT_COUNT
+  else
+    SUBBOT_COUNT=$OLD_SUBBOT_COUNT
+  fi
 
   if [ "$SESSION_COUNT" -gt 2 ]; then
     ok "Sesiones encontradas: ${NEON_GREEN}${BOLD}$((SESSION_COUNT-2)) archivos${NC}"
@@ -414,7 +448,9 @@ if $UPDATE_MODE; then
   docker stop vaniabot 2>/dev/null \
     && ok "vaniabot ${GHOST}detenido${NC}" \
     || warn "vaniabot no estaba corriendo"
-  sleep 2   
+  sleep 2
+
+  migrate_subbot_sessions
 
   fix_permissions "vaniabot_session"          "/app/vaniasession"
   fix_permissions "vaniabot_database"         "/app/data"

--- a/src/commands/media/ToAnimeCommand.ts
+++ b/src/commands/media/ToAnimeCommand.ts
@@ -32,14 +32,7 @@ export class ToAnimeCommand extends Command {
 
     if (!env.DEEPAI_API_KEY) {
       await ctx.reply(
-        `˚₊· ͟͟͞͞➳ *API no configurada* ˚₊· ͟͟͞͞➳\n\n` +
-          `❌ No tienes configurada la API de DeepAI.\n\n` +
-          `Para activar esta función:\n` +
-          `1. Regístrate en https://deepai.org\n` +
-          `2. Ve a https://deepai.org/dashboard\n` +
-          `3. Copia tu API key\n` +
-          `4. Agrégala en .env como:\n` +
-          `DEEPAI_API_KEY=tu_key`,
+        `❌ API KEY no establecida, esta función se encuentra temporalmente inhabilitada hasta que se agregue una api key funcional`,
       );
       return;
     }

--- a/src/commands/utility/tools/NoticiasCommand.ts
+++ b/src/commands/utility/tools/NoticiasCommand.ts
@@ -42,7 +42,7 @@ export class NoticiasCommand extends Command {
 
     if (articles.length === 0 || !articles[0].url) {
       await ctx.reply(
-        `❌ No encontré noticias. La API puede no estar configurada.\n\nAgrega *NEWSDATA_API_KEY* a tu archivo .env`,
+        `❌ API KEY no establecida, esta función se encuentra temporalmente inhabilitada hasta que se agregue una api key funcional`,
       );
       return;
     }

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -131,6 +131,21 @@ const envSchema = z.object({
   /** DeepAI API key for image processing (get at https://deepai.org) */
   DEEPAI_API_KEY: z.string().optional(),
 
+  /** NewsData.io API key for news features (get at https://newsdata.io) */
+  NEWSDATA_API_KEY: z.string().optional(),
+
+  /** Pixabay API key for image search (get at https://pixabay.com/api/docs) */
+  PIXABAY_API_KEY: z.string().optional(),
+
+  /** Pexels API key for image search (get at https://pexels.com/api) */
+  PEXELS_API_KEY: z.string().optional(),
+
+  /** Gemini API key for AI fallback (get at https://makersuite.google.com/app/apikey) */
+  GEMINI_API_KEY: z.string().optional(),
+
+  /** Panel webhook token for API authentication */
+  PANEL_WEBHOOK_TOKEN: z.string().optional(),
+
   /** Log level: error | warn | info | debug */
   LOG_LEVEL: z
     .enum(['error', 'warn', 'info', 'debug'])

--- a/src/config/subbot.ts
+++ b/src/config/subbot.ts
@@ -1,3 +1,9 @@
+const SESSION_BASE_PATH = process.env.SUBBOT_SESSIONS_PATH
+  ? process.env.SUBBOT_SESSIONS_PATH
+  : process.env.DOCKER_MODE === 'true'
+    ? '/app/subbot-sessions'
+    : './data/subbot-sessions';
+
 export const SUBBOT_CONFIG = {
   MAX_SLOTS: 50,
   DEFAULT_SLOTS: 15,
@@ -5,7 +11,7 @@ export const SUBBOT_CONFIG = {
   PUBLIC_REQUESTS: true,
   SLOT_STAGGER_MS: 700,
   SLOT_STAGGER_MAX_MS: 8000,
-  SESSION_BASE_PATH: './data/subbot-sessions',
+  SESSION_BASE_PATH,
   RUNTIME_STATE_DIR: './data/runtime/bot-states',
   BOT_RUNTIME_STATE_TTL_MS: 120000,
   RUNTIME_STATE_WRITE_DEBOUNCE_MS: 5000,

--- a/src/services/external/AIService.ts
+++ b/src/services/external/AIService.ts
@@ -192,7 +192,7 @@ interface GroqError {
  */
 export class AIService {
   /** Groq SDK client instance. */
-  private client: Groq;
+  private client: Groq | null;
 
   /**
    * In-memory session store.
@@ -216,17 +216,16 @@ export class AIService {
    * Creates and initializes the AIService.
    * Loads existing sessions from database if available.
    *
-   * @throws {Error} If `GROQ_API_KEY` is not set in the environment.
    */
   constructor() {
     if (!env.GROQ_API_KEY) {
-      throw new Error(
-        'GROQ_API_KEY no está configurada en el .env\n' +
-          'Obtén tu key gratis en: https://console.groq.com/keys',
+      logger.warn(
+        'API KEY no establecida, esta función se encuentra temporalmente inhabilitada hasta que se agregue una api key funcional',
       );
+      this.client = null;
+    } else {
+      this.client = new Groq({ apiKey: env.GROQ_API_KEY });
     }
-
-    this.client = new Groq({ apiKey: env.GROQ_API_KEY });
 
     if (!fs.existsSync(TEMP_DIR)) {
       fs.mkdirSync(TEMP_DIR, { recursive: true });
@@ -588,6 +587,10 @@ export class AIService {
     userMessage: string,
     fast = false,
   ): Promise<AIResponse> {
+    if (!this.client) {
+      return left(new ServiceUnavailableError('API KEY no establecida, esta función se encuentra temporalmente inhabilitada hasta que se agregue una api key funcional'));
+    }
+    const client = this.client;
     if (!userMessage.trim()) {
       return left(new ValidationError('El mensaje no puede estar vacío'));
     }
@@ -627,7 +630,7 @@ export class AIService {
         return await retryManager.retryOperation(
           'ai-chat',
           async () => {
-            const completion = await this.client.chat.completions.create({
+            const completion = await client.chat.completions.create({
               model: fast ? GROQ_MODELS.fast : GROQ_MODELS.chat,
               messages,
               max_tokens: 1024,
@@ -689,6 +692,10 @@ export class AIService {
    * ```
    */
   async generate(prompt: string, maxTokens = 512): Promise<AIResponse> {
+    if (!this.client) {
+      return left(new ServiceUnavailableError('API KEY no establecida, esta función se encuentra temporalmente inhabilitada hasta que se agregue una api key funcional'));
+    }
+    const client = this.client;
     const cacheKey = this.generateCacheKey(prompt, 'generate', false);
     const cached = await this.getCachedResponse(cacheKey);
 
@@ -708,7 +715,7 @@ export class AIService {
         return await retryManager.retryOperation(
           'ai-generate',
           async () => {
-            const completion = await this.client.chat.completions.create({
+            const completion = await client.chat.completions.create({
               model: GROQ_MODELS.chat,
               messages: [
                 { role: 'system', content: getSystemPrompt('> VaniaBot💝', UserTier.USER) },
@@ -752,6 +759,10 @@ export class AIService {
     customSystemPrompt: string,
     _storeName?: string,
   ): Promise<string> {
+    if (!this.client) {
+      return 'API KEY no establecida, esta función se encuentra temporalmente inhabilitada hasta que se agregue una api key funcional';
+    }
+    const client = this.client;
     try {
       const circuitBreaker = circuitBreakerManager.getOrCreate('ai-store', {
         failureThreshold: 3,
@@ -764,7 +775,7 @@ export class AIService {
         return await retryManager.retryOperation(
           'ai-store-chat',
           async () => {
-            const completion = await this.client.chat.completions.create({
+            const completion = await client.chat.completions.create({
               model: GROQ_MODELS.chat,
               messages: [
                 { role: 'system', content: customSystemPrompt },
@@ -824,12 +835,16 @@ export class AIService {
     extension: string = 'ogg',
     language?: string,
   ): Promise<AIResponse> {
+    if (!this.client) {
+      return left(new ServiceUnavailableError('API KEY no establecida, esta función se encuentra temporalmente inhabilitada hasta que se agregue una api key funcional'));
+    }
+    const client = this.client;
     const tmpPath = path.join(TEMP_DIR, `voice_${Date.now()}.${extension}`);
 
     try {
       fs.writeFileSync(tmpPath, audioBuffer);
 
-      const transcription = await this.client.audio.transcriptions.create({
+      const transcription = await client.audio.transcriptions.create({
         file: fs.createReadStream(tmpPath),
         model: GROQ_MODELS.transcribe,
         ...(language ? { language } : {}),

--- a/src/services/external/ImageService.ts
+++ b/src/services/external/ImageService.ts
@@ -1,7 +1,6 @@
 import axios, { type AxiosResponse } from 'axios';
 import { logger } from '@/utils/logger.js';
-import dotenv from 'dotenv';
-dotenv.config();
+import { env } from '@/config/env.js';
 
 interface ImageResult {
   id: number | string;
@@ -86,7 +85,7 @@ export class ImageService {
     let results: ImageResult[] = [];
 
     // 1. Intentar con Pixabay (más confiable)
-    if (process.env.PIXABAY_API_KEY) {
+    if (env.PIXABAY_API_KEY) {
       try {
         logger.info(`[ImageService] 🔍 Buscando en Pixabay: "${query}" (${perPage} resultados)`);
         results = await this.searchPixabay(query, perPage);
@@ -101,7 +100,7 @@ export class ImageService {
     }
 
     // 2. Intentar con Pexels si Pixabay no devolvió resultados
-    if (!results.length && process.env.PEXELS_API_KEY) {
+    if (!results.length && env.PEXELS_API_KEY) {
       try {
         logger.info(`[ImageService] 🔍 Buscando en Pexels: "${query}" (${perPage} resultados)`);
         results = await this.searchPexels(query, perPage);
@@ -173,7 +172,7 @@ export class ImageService {
   }
 
   private async searchPixabay(query: string, perPage: number): Promise<ImageResult[]> {
-    const apiKey = process.env.PIXABAY_API_KEY;
+    const apiKey = env.PIXABAY_API_KEY;
     if (!apiKey) {
       logger.warn('[ImageService] PIXABAY_API_KEY no está configurada');
       return [];

--- a/src/services/external/NewsService.ts
+++ b/src/services/external/NewsService.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { logError } from '@/utils/logger.js';
+import { env } from '@/config/env.js';
 
 interface NewsArticle {
   title: string;
@@ -12,7 +13,7 @@ interface NewsArticle {
 export class NewsService {
   private static instance: NewsService;
   private readonly NEWS_API = 'https://newsdata.io/api/1/news';
-  private readonly API_KEY = process.env.NEWSDATA_API_KEY;
+  private readonly API_KEY = env.NEWSDATA_API_KEY;
 
   static getInstance(): NewsService {
     if (!NewsService.instance) {
@@ -98,7 +99,8 @@ export class NewsService {
     return [
       {
         title: 'Noticias no disponibles',
-        description: 'La API de noticias no está configurada. Agrega NEWSDATA_API_KEY a tu .env',
+        description:
+          'API KEY no establecida, esta función se encuentra temporalmente inhabilitada hasta que se agregue una api key funcional',
         url: '',
         source: 'Sistema',
         publishedAt: '',

--- a/src/services/external/providers/AIFallbackChain.ts
+++ b/src/services/external/providers/AIFallbackChain.ts
@@ -19,9 +19,8 @@ export class AIFallbackChain {
       logger.info('[AI Chain] Groq provider registered');
     }
 
-    const geminiKey = process.env.GEMINI_API_KEY;
-    if (geminiKey) {
-      this.providers.push(new GeminiProvider(geminiKey));
+    if (env.GEMINI_API_KEY) {
+      this.providers.push(new GeminiProvider(env.GEMINI_API_KEY));
       logger.info('[AI Chain] Gemini provider registered');
     }
 

--- a/src/services/media/ToAnimeService.ts
+++ b/src/services/media/ToAnimeService.ts
@@ -73,11 +73,7 @@ export class ToAnimeService {
     return {
       success: false,
       error:
-        'DeepAI API no disponible. Configura DEEPAI_API_KEY en .env para usar esta función.\n\n' +
-        '1. Regístrate en https://deepai.org\n' +
-        '2. Ve a https://deepai.org/dashboard\n' +
-        '3. Copia tu API key\n' +
-        '4. Agrégala en .env como DEEPAI_API_KEY=tu_key',
+        'API KEY no establecida, esta función se encuentra temporalmente inhabilitada hasta que se agregue una api key funcional',
     };
   }
 }

--- a/src/services/subbot/SubBotDatabase.ts
+++ b/src/services/subbot/SubBotDatabase.ts
@@ -9,6 +9,7 @@
  */
 
 import { getDatabase } from '@/repositories/Database.js';
+import { SUBBOT_CONFIG } from '@/config/subbot.js';
 import type { SubBotConfig, SubBotSlot, SubBotSlotStatus } from '@/types/subbot.js';
 import { logger } from '@/utils/logger.js';
 
@@ -125,7 +126,7 @@ export class SubBotDatabase {
       ownerJid: slot.ownerJid || '',
       ownerName: slot.ownerName || '',
       phoneNumber: slot.phoneNumber || '',
-      sessionPath: `./data/subbot-sessions/${slot.id}`,
+      sessionPath: `${SUBBOT_CONFIG.SESSION_BASE_PATH}/${slot.id}`,
       prefix: '.',
       name: slot.name || `VaniaBot-${slot.slot}`,
       active: slot.status === 'connected',

--- a/src/services/subbot/SubBotManager.ts
+++ b/src/services/subbot/SubBotManager.ts
@@ -19,7 +19,15 @@
  */
 
 import { randomBytes } from 'crypto';
-import { rmSync, existsSync, mkdirSync, readFileSync, writeFileSync, renameSync } from 'fs';
+import {
+  rmSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+  renameSync,
+} from 'fs';
 import { EventEmitter } from 'events';
 import type { WAMessage, proto, WASocket } from '@whiskeysockets/baileys';
 import type {
@@ -100,14 +108,22 @@ export class SubBotManager extends EventEmitter {
   async initialize(): Promise<void> {
     logger.info('🌸 Iniciando SubBotManager (VaniaBot)...');
 
+    this.recoverOrphanedSessions();
+
     const activeSlots = subBotDatabase.getActiveSlots();
     logger.info(`📦 ${activeSlots.length} slots activos encontrados`);
 
     for (const slot of activeSlots) {
       if (slot.id) {
-        const subConfig = subBotDatabase.get(slot.id);
-        if (subConfig) {
-          await this.launchInstance(subConfig);
+        if (slot.status === 'connected' || slot.status === 'linking') {
+          const subConfig = subBotDatabase.get(slot.id);
+          if (subConfig) {
+            await this.launchInstance(subConfig);
+          }
+        } else if (slot.status === 'disconnected') {
+          logger.info(
+            `⏭️ SubBot[${slot.id}] slot ${slot.slot} disconnected — omitiendo auto-reconexión`,
+          );
         }
       }
     }
@@ -116,6 +132,49 @@ export class SubBotManager extends EventEmitter {
     this.startSettingsSync();
 
     logger.info('✅ SubBotManager inicializada correctamente');
+  }
+
+  private recoverOrphanedSessions(): void {
+    const sessionDir = SUBBOT_CONFIG.SESSION_BASE_PATH;
+    if (!existsSync(sessionDir)) return;
+
+    let recovered = 0;
+    try {
+      const entries = readdirSync(sessionDir);
+      const sessionIds = entries.filter(e => {
+        const dirPath = `${sessionDir}/${e}`;
+        if (!existsSync(dirPath)) return false;
+        const files = readdirSync(dirPath);
+        return files.some(f => f.endsWith('.json'));
+      });
+
+      const allSlots = subBotDatabase.getAllSlots();
+
+      for (const sessionId of sessionIds) {
+        const matchingSlot = allSlots.find(s => s.id === sessionId);
+
+        if (!matchingSlot) continue;
+
+        if (matchingSlot.status === 'free') {
+          logger.info(
+            `🔧 Session ${sessionId} found in free slot ${matchingSlot.slot}, recovering`,
+          );
+          subBotDatabase.updateSlotStatus(matchingSlot.slot, 'disconnected');
+          recovered++;
+        } else if (matchingSlot.status === 'disconnected') {
+          logger.info(
+            `⏭️ Session ${sessionId} slot ${matchingSlot.slot} disconnected — esperando acción manual`,
+          );
+        }
+      }
+    } catch (error) {
+      logError('Session recovery failed', error);
+      return;
+    }
+
+    if (recovered > 0) {
+      logger.info(`✅ Recovered ${recovered} orphaned session(s)`);
+    }
   }
 
   private startHealthCheck(): void {
@@ -129,6 +188,8 @@ export class SubBotManager extends EventEmitter {
 
         for (const slot of activeSlots) {
           if (!slot.id) continue;
+
+          if (slot.status === 'disconnected') continue;
 
           const instance = this.instances.get(slot.id);
           const runtimeState = this.runtimeStates.get(slot.id);
@@ -673,9 +734,19 @@ export class SubBotManager extends EventEmitter {
     instance.on('sessionInvalid', () => {
       void (async () => {
         if (!this.mainSock) return;
-        logger.warn(`⚠️ SubBot[${subConfig.id}] sesión inválida, notificando owner`);
+        logger.warn(`⚠️ SubBot[${subConfig.id}] sesión inválida, limpiando y notificando owner`);
 
         subBotDatabase.updateSlotStatus(subConfig.slot, 'disconnected');
+
+        const sessionPath = `${SUBBOT_CONFIG.SESSION_BASE_PATH}/${subConfig.id}`;
+        if (existsSync(sessionPath)) {
+          try {
+            rmSync(sessionPath, { recursive: true, force: true });
+            logger.info(`🗑️ SubBot[${subConfig.id}] sesión corrupta eliminada de ${sessionPath}`);
+          } catch (err) {
+            logger.warn(`SubBot[${subConfig.id}] no se pudo limpiar sesión: ${err}`);
+          }
+        }
 
         try {
           await this.mainSock.sendMessage(subConfig.ownerJid, {

--- a/src/services/webhook/PanelServer.ts
+++ b/src/services/webhook/PanelServer.ts
@@ -27,6 +27,7 @@ import { healthCheckService } from '@/services/system/HealthCheckService.js';
 import { cacheManager } from '@/core/CacheManager.js';
 import type { WhatsAppClient } from '@/core/Client.js';
 import { logger } from '@/utils/logger.js';
+import { env } from '@/config/env.js';
 
 /**
  * Configuration interface for the Panel server.
@@ -55,7 +56,7 @@ export interface PanelConfig {
 const DEFAULT_CONFIG: PanelConfig = {
   port: process.env.PANEL_PORT ? parseInt(process.env.PANEL_PORT) : 3000,
   host: process.env.PANEL_HOST || '0.0.0.0',
-  webhookToken: process.env.PANEL_WEBHOOK_TOKEN || '',
+  webhookToken: env.PANEL_WEBHOOK_TOKEN || '',
   allowedOrigins: process.env.PANEL_ALLOWED_ORIGINS?.split(',') || ['*'],
   panelPath: process.env.PANEL_PATH || './panel',
   callbackSecret: process.env.PANEL_CALLBACK_SECRET,

--- a/src/utils/ErrorHandler.ts
+++ b/src/utils/ErrorHandler.ts
@@ -4,7 +4,7 @@
  * Centralized error handling for VaniaBot.
  * Provides user-friendly error messages, logging, and retry logic.
  *
- * @author **Carlos G** ⭐
+ * @author **Carlos G**
  */
 
 import { logger, logError } from '@/utils/logger.js';
@@ -90,7 +90,7 @@ export class ErrorHandler {
     const errorMessage = error instanceof Error ? error.message : String(error);
 
     if (errorMessage.includes('401') || errorMessage.includes('API key')) {
-      return '⚠️ Error de API AI. Verifica GROQ_API_KEY en .env';
+      return '⚠️ API KEY no establecida, esta función se encuentra temporalmente inhabilitada';
     }
 
     if (errorMessage.includes('429') || errorMessage.includes('rate_limit')) {


### PR DESCRIPTION
## What

Fixes two independent bugs affecting service startup and subbot data integrity.

## Changes

**Subbot persistence (`subbot`)**
- Fixed a bug where subbot data was not being persisted correctly, causing data loss between restarts.
- Improved handling of missing or incomplete data on read, preventing crashes when records were in an unexpected state.

**API key initialization (`services`)**
- Services no longer throw on startup when an optional API key is absent.
- Missing keys are now handled gracefully: the affected service is skipped or disabled rather than crashing the whole process.
- Updated `ErrorHandler` to reflect these new failure modes.

**Cleanup**
- Updated `deploy.sh` and adjusted commands/services (`ToAnimeCommand`, `ToAnimeService`, `NoticiasCommand`, `PanelServer`) that were impacted by the above changes.

## Testing

- [ ] Restart service with one or more API keys removed — no crash on startup
- [ ] Restart service and verify subbot data survives across restarts
- [ ] Affected commands (`!anime`, `!noticias`) respond correctly when their API key is missing